### PR TITLE
Refactor server API exposure and detector initialization

### DIFF
--- a/NexusGuard/client_main.lua
+++ b/NexusGuard/client_main.lua
@@ -27,14 +27,11 @@ if not EventRegistry then
     -- Consider adding logic here to halt initialization if EventRegistry is crucial and missing.
 end
 
--- Detector Registry Module
 local DetectorRegistry = require('shared/detector_registry')
 if not DetectorRegistry then
     print("^1[NexusGuard] CRITICAL: Failed to load shared/detector_registry.lua. Detector management will fail.^7")
     -- Consider halting initialization if the registry is crucial.
 end
-
--- REMOVED _G.NexusGuard ASSIGNMENT
 
 -- Environment Check & Debug Compatibility
 -- Attempts to detect if running outside a standard FiveM client environment (e.g., for testing).
@@ -161,7 +158,6 @@ local isDebugEnvironment = type(Citizen) ~= "table" or type(Citizen.CreateThread
             -- 3. Add `Config.Detectors.mydetector = true` (or false) to config.lua.
         }
     }
-    -- _G.NexusGuard = NexusGuardInstance -- REMOVED: Avoid global assignment. Instance passed via Initialize.
 
     --[[
         Safe Detection Wrapper (Called by detector threads)
@@ -352,7 +348,7 @@ local isDebugEnvironment = type(Citizen) ~= "table" or type(Citizen.CreateThread
                     -- Call the detector's Initialize function if it exists.
                     -- Pass the core NexusGuard instance (self) and the EventRegistry for the detector to use.
                     if detectorModule.Initialize and type(detectorModule.Initialize) == "function" then
-                        local initSuccess, initErr = pcall(detectorModule.Initialize, self, EventRegistry)
+                        local initSuccess, initErr = pcall(detectorModule.Initialize, self)
                         if not initSuccess then
                             print(("^1[NexusGuard] Error initializing detector '%s': %s^7"):format(detectorName, tostring(initErr)))
                             -- Consider unregistering or marking as failed if init fails?

--- a/NexusGuard/server/server_main.lua
+++ b/NexusGuard/server/server_main.lua
@@ -22,11 +22,10 @@
 local EventRegistry = require('shared/event_registry') -- Handles standardized network event names.
 
 -- NexusGuard Server API (from globals.lua)
--- This table provides access to functions and data from other server-side modules.
-local NexusGuardServer = exports['NexusGuard']:GetNexusGuardServerAPI()
+-- Require the API table directly instead of using globals or exports.
+local NexusGuardServer = require('globals')
 if not NexusGuardServer then
-    print("^1[NexusGuard] CRITICAL: Failed to get NexusGuardServer API from globals.lua. NexusGuard will not function correctly.^7")
-    -- Consider stopping the resource if the API is essential.
+    print("^1[NexusGuard] CRITICAL: Failed to load NexusGuardServer API from globals.lua. NexusGuard will not function correctly.^7")
     return
 end
 


### PR DESCRIPTION
## Summary
- expose IsPlayerAdmin and BanPlayer through NexusGuardServer and return the API table from globals
- load globals.lua directly in server_main to access the API without exports
- initialize detectors with the NexusGuard instance in client_main, removing _G usage

## Testing
- `lua tests/module_loader_test.lua` *(failed: Load a non-existent module, Load an optional module, Clear cache)*
- `lua tests/natives_test.lua` *(failed: Native function exists, Successful native call, Failed native call, Error handling)*

------
https://chatgpt.com/codex/tasks/task_e_68973e545aac83279bf2feeec9fa204f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new admin API functions: ability to check if a player is an admin and to ban players directly, including specifying reason, duration, and admin name.

* **Refactor**
  * Improved module structure for accessing the server API.
  * Updated detector initialization to streamline arguments and removed exposure of core instance as a global variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->