### PR TITLE
Ensure resource check events validate session state

### DIFF
--- a/NexusGuard/docs/validated_event_patterns.md
+++ b/NexusGuard/docs/validated_event_patterns.md
@@ -1,0 +1,13 @@
+# Validated Event Patterns
+
+This document records client-to-server events that include built-in validation.
+
+## `SYSTEM_RESOURCE_CHECK`
+- **Client**: `client/detectors/resourcemonitor_detector.lua` triggers the event with a list of running resources and the client's security token.
+- **Server**: `server/server_main.lua` validates the security token, confirms the player's session, updates activity, and checks the provided resources against configured allow/deny lists.
+
+## `NEXUSGUARD_WEAPON_CHECK`
+- **Client**: `client/detectors/weaponmod_detector.lua` contains a commented example showing how the detector should send the weapon hash, clip count, and security token.
+- **Server**: `server/server_main.lua` verifies the security token, ensures a valid player session, and compares the reported clip size to the configured threshold for that weapon.
+
+These patterns ensure that sensitive client reports are authenticated and cross‑checked server-side before any action is taken.

--- a/NexusGuard/server/server_main.lua
+++ b/NexusGuard/server/server_main.lua
@@ -374,6 +374,18 @@ function RegisterNexusGuardServerEvents()
             return
         end
 
+        -- Retrieve player session via API.
+        local session = NexusGuardServer.GetSession(source)
+        if not session or not session.metrics then
+            Log(("^1[NexusGuard] API Player session or metrics not found for %s (ID: %d) during resource check.^7"):format(playerName, source), 1)
+            return
+        end
+
+        -- Mark the session as active.
+        if NexusGuardServer.Session and NexusGuardServer.Session.UpdateActivity then
+            NexusGuardServer.Session.UpdateActivity(source)
+        end
+
         Log(("^3[NexusGuard]^7 Received resource list from %s (ID: %d) (%d resources) via event '%s'^7"):format(playerName, source, #clientResourcesList, EventRegistry:GetEventName('SYSTEM_RESOURCE_CHECK')), 3)
 
         -- Check if resource verification is enabled in the config.
@@ -430,7 +442,6 @@ function RegisterNexusGuardServerEvents()
                     NexusGuardServer.Discord.Send("general", "Resource Mismatch", ("Player: %s (ID: %d)\nReason: %s"):format(playerName, source, reason), NexusGuardServer.Config.Discord.webhooks and NexusGuardServer.Config.Discord.webhooks.general)
                 end
                 -- Process this as a detection event.
-                local session = NexusGuardServer.GetSession(source) -- Get session via API
                 if NexusGuardServer.Detections and NexusGuardServer.Detections.Process then
                     NexusGuardServer.Detections.Process(source, "ResourceMismatch", { mismatched = MismatchedResources, mode = checkMode }, session)
                 end


### PR DESCRIPTION
## Summary
- Validate server-side session and activity in `SYSTEM_RESOURCE_CHECK` handler before evaluating client resource lists
- Record vetted client-to-server event patterns for future reference

## Testing
- `lua tests/module_loader_test.lua` *(fails: Load a non-existent module, Load an optional module, Clear cache)*
- `lua tests/natives_test.lua` *(fails: Native function exists, Successful native call, Failed native call, Error handling)*

------
https://chatgpt.com/codex/tasks/task_e_68973e5f0f7483278113966163dfb8c1