### PR TITLE
feat: add configurable logging and server thresholds

### DIFF
--- a/NexusGuard/config.lua
+++ b/NexusGuard/config.lua
@@ -2,11 +2,18 @@ Config = {}
 
 -- General Settings
 Config.ServerName = "My Awesome FiveM Server" -- Your server name (You can change this later)
-Config.LogLevel = 1 -- Production default
 Config.EnableDiscordLogs = false -- DISABLED: Enable Discord webhook logs (Separate from LogLevel)
 Config.DiscordWebhook = "" -- Your Discord webhook URL (General logs if specific webhooks below aren't set)
 Config.BanMessage = "You have been banned for cheating. Appeal at: discord.gg/yourserver" -- Ban message
 Config.KickMessage = "You have been kicked for suspicious activity." -- Kick message
+
+-- Logging
+Config.LogLevel = 1 -- Production default
+
+-- Server-Side Threshold Settings
+Config.serverSideSpeedThreshold = 50.0 -- Max allowed speed in m/s based on server position checks (Approx 180 km/h). Tune carefully!
+Config.serverSideRegenThreshold = 3.0 -- Max allowed passive HP regen rate in HP/sec based on server health checks.
+Config.serverSideArmorThreshold = 105.0 -- Max allowed armor value based on server health checks (Allows slight buffer over 100).
 
 -- Permissions Framework Configuration
 -- Set this to match your server's permission system. Affects the IsPlayerAdmin check in globals.lua.
@@ -56,10 +63,10 @@ Config.Thresholds = {
     aiDecisionConfidenceThreshold = 0.75, -- AI confidence threshold for automated action
 
     -- Server-Side Validation Thresholds (Used by server checks, independent of client checks)
-    serverSideSpeedThreshold = 50.0, -- Max allowed speed in m/s based on server position checks (Approx 180 km/h). Tune carefully!
+    serverSideSpeedThreshold = Config.serverSideSpeedThreshold,
     minTimeDiffPositionCheck = 450, -- Minimum time in milliseconds between server-side position checks to calculate speed. Lower values are more sensitive but prone to false positives due to network jitter.
-    serverSideRegenThreshold = 3.0, -- Max allowed passive HP regen rate in HP/sec based on server health checks.
-    serverSideArmorThreshold = 105.0, -- Max allowed armor value based on server health checks (Allows slight buffer over 100).
+    serverSideRegenThreshold = Config.serverSideRegenThreshold,
+    serverSideArmorThreshold = Config.serverSideArmorThreshold,
 
     spawnGracePeriod = 5, -- Seconds to ignore speed checks after spawn
     teleportGracePeriod = 3, -- Seconds to ignore position jumps after resource start/teleport

--- a/NexusGuard/globals.lua
+++ b/NexusGuard/globals.lua
@@ -23,15 +23,19 @@
 -- - oxmysql: Required for database operations
 -- - screenshot-basic: Required for screenshot functionality
 
--- Load the Utils module first (needed for logging)
 local Utils = require('server/sv_utils')
 
--- Local alias for logging function from the Utils module
-local Log = Utils.Log
-if not Log then
-    print("^1[NexusGuard] CRITICAL: Logging function (Utils.Log) not found after requiring sv_utils.lua.^7")
-    Log = function(msg, level) print(msg) end -- Basic fallback
+-- Logging function that respects Config.LogLevel.
+local function Log(message, level)
+    level = level or 2 -- Default to Info level
+    local configLogLevel = (_G.Config and _G.Config.LogLevel) or 2
+    if level <= configLogLevel then
+        print("[NexusGuard] " .. message)
+    end
 end
+
+-- Expose the log function through Utils for other modules.
+Utils.Log = Log
 
 -- Load the Core module which will handle all other modules
 local Core = require('server/sv_core')


### PR DESCRIPTION
## Summary
- add logging level option and server-side speed, regen, armor thresholds to config
- update global Log helper to respect Config.LogLevel
- use configured thresholds in server-side fallback checks for position and health events

## Testing
- `lua tests/module_loader_test.lua` *(fails: Non-existent module should return nil)*
- `lua tests/natives_test.lua` *(fails: IsDuplicityVersion should exist in the Natives wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68973e606ad88327ac02ec6d574b9956