### PR TITLE
refactor: rename error variable in test helper

### DIFF
--- a/NexusGuard/tests/module_loader_test.lua
+++ b/NexusGuard/tests/module_loader_test.lua
@@ -63,12 +63,12 @@ local tests = {
 -- Test function
 local function test(name, func)
     tests.total = tests.total + 1
-    local status, error = pcall(func)
+    local status, err = pcall(func)
     if status then
         print(string.format("✓ Test passed: %s", name))
         tests.passed = tests.passed + 1
     else
-        print(string.format("✗ Test failed: %s\n  Error: %s", name, error))
+        print(string.format("✗ Test failed: %s\n  Error: %s", name, err))
         tests.failed = tests.failed + 1
     end
 end


### PR DESCRIPTION
## Summary
- refactor test helper in module loader tests to use `err` variable for error messages

## Testing
- `lua tests/module_loader_test.lua` *(fails: 4 passed, 3 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68973eff88c48327a40ba2bb4cb1a323