### PR TITLE
Add TableSize utility helper

### DIFF
--- a/NexusGuard/docs/core_modules.md
+++ b/NexusGuard/docs/core_modules.md
@@ -101,12 +101,12 @@ local Utils = ModuleLoader.Load('shared/utils')
 Utils.Log("Player connected: %s", Utils.logLevels.INFO, playerName)
 ```
 
-#### `Utils.TableSize(table)`
+#### `Utils.TableSize(tbl)`
 
-Returns the number of elements in a table.
+Returns the number of key-value pairs in a table.
 
 **Parameters:**
-- `table` (table): The table to count elements in
+- `tbl` (table): The table to count elements in
 
 **Returns:**
 - (number): The number of elements in the table

--- a/NexusGuard/shared/utils.lua
+++ b/NexusGuard/shared/utils.lua
@@ -220,6 +220,20 @@ function Utils.SerializeTable(tbl, indent)
     return result .. string.rep("  ", indent) .. "}"
 end
 
+-- Count the number of entries in a table
+function Utils.TableSize(tbl)
+    if type(tbl) ~= "table" then
+        return 0
+    end
+
+    local count = 0
+    for _ in pairs(tbl) do
+        count = count + 1
+    end
+
+    return count
+end
+
 -- Secure hash function with fallbacks
 function Utils.Hash(data, algorithm)
     algorithm = algorithm or "sha256"


### PR DESCRIPTION
## Summary
- add `Utils.TableSize` helper to count entries in a table
- document `Utils.TableSize` in core modules guide

## Testing
- `lua tests/module_loader_test.lua` *(fails: Non-existent module should return nil; Optional non-existent module should return nil without error; Different module instances should be returned after clearing cache)*
- `lua tests/natives_test.lua` *(fails: IsDuplicityVersion should exist in the Natives wrapper; GetEntityCoords should return the correct x coordinate; GetPlayerName should return nil for a failed call; GetPlayerName should handle errors and return nil)*


------
https://chatgpt.com/codex/tasks/task_e_68973f02d4548327a487d9f3f37739cb