### PR TITLE
Add LoadByName tests for module loader

### DIFF
--- a/NexusGuard/tests/module_loader_test.lua
+++ b/NexusGuard/tests/module_loader_test.lua
@@ -132,8 +132,20 @@ test("Clear cache", function()
     assert(moduleA1 ~= moduleA2, "Different module instances should be returned after clearing cache")
 end)
 
+-- Test: Load module by short name
+test("Load module by short name", function()
+    local utilsModule = ModuleLoader.LoadByName('utils')
+    assert(utilsModule ~= nil, "Utils module should be loaded by short name")
+end)
+
+-- Test: Handle unknown short module name
+test("Handle unknown short module name", function()
+    local unknown = ModuleLoader.LoadByName('unknownModule')
+    assert(unknown == nil or next(unknown) == nil, "Unknown module should return nil or an empty table")
+end)
+
 -- Print test summary
-print(string.format("\nTest Summary: %d passed, %d failed, %d total", 
+print(string.format("\nTest Summary: %d passed, %d failed, %d total",
     tests.passed, tests.failed, tests.total))
 
 -- Restore the original require function


### PR DESCRIPTION
## Summary
- test ModuleLoader.LoadByName can load known short names
- check behavior when an unknown short name is requested

## Testing
- `lua tests/module_loader_test.lua` *(fails: Load a non-existent module, Load an optional module, Clear cache)*
- `lua tests/natives_test.lua` *(fails: Native function exists, Successful native call, Failed native call, Error handling)*

------
https://chatgpt.com/codex/tasks/task_e_68973f0463cc8327930fed175225c41c