### PR TITLE
refactor: rename pcall error variable in module loader test

### DIFF
--- a/NexusGuard/tests/module_loader_test.lua
+++ b/NexusGuard/tests/module_loader_test.lua
@@ -63,12 +63,12 @@ local tests = {
 -- Test function
 local function test(name, func)
     tests.total = tests.total + 1
-    local status, error = pcall(func)
+    local status, err = pcall(func)
     if status then
         print(string.format("✓ Test passed: %s", name))
         tests.passed = tests.passed + 1
     else
-        print(string.format("✗ Test failed: %s\n  Error: %s", name, error))
+        print(string.format("✗ Test failed: %s\n  Error: %s", name, err))
         tests.failed = tests.failed + 1
     end
 end


### PR DESCRIPTION
## Summary
- rename `pcall`'s error return value to `err`
- update failure print statement to reference `err`

## Testing
- `lua tests/module_loader_test.lua` (fails: Load a non-existent module, Load an optional module, Clear cache)


------
https://chatgpt.com/codex/tasks/task_e_689789866050832786cedc2eaba22e91