### PR TITLE
feat: retry NexusGuard API acquisition

### DIFF
--- a/NexusGuard/tests/utils_log_test.lua
+++ b/NexusGuard/tests/utils_log_test.lua
@@ -1,0 +1,71 @@
+--[[
+    NexusGuard Utils Logging Test (tests/utils_log_test.lua)
+
+    Purpose:
+    - Ensures NexusGuard API is reacquired after using fallback
+    - Verifies RefreshNexusGuardAPI forces lookup
+]]
+
+local Utils = require('shared/utils')
+
+local tests = { passed = 0, failed = 0, total = 0 }
+
+local function test(name, fn)
+    tests.total = tests.total + 1
+    local ok, err = pcall(fn)
+    if ok then
+        print(string.format("✓ Test passed: %s", name))
+        tests.passed = tests.passed + 1
+    else
+        print(string.format("✗ Test failed: %s\n  Error: %s", name, err))
+        tests.failed = tests.failed + 1
+    end
+end
+
+-- Test: Reacquires API when it becomes available
+test("Reacquires API after fallback", function()
+    -- Ensure clean state
+    Utils.nexusGuardAPI = nil
+    Utils.nexusGuardAPIDummy = nil
+    _G.NexusGuard = nil
+
+    local fallbackLogs = {}
+    local originalPrint = print
+    print = function(...)
+        table.insert(fallbackLogs, table.concat({...}, " "))
+    end
+
+    -- First log uses fallback
+    Utils.Log("fallback")
+    assert(#fallbackLogs > 0, "Fallback log should be recorded")
+
+    -- Provide real API
+    local apiLogs = {}
+    _G.NexusGuard = { Utils = { Log = function(msg) table.insert(apiLogs, msg) end }, Config = {} }
+
+    -- Next log should use real API via reacquisition
+    Utils.Log("real")
+    assert(#apiLogs > 0, "Real API should capture log")
+    assert(Utils.GetNexusGuardAPI() == _G.NexusGuard, "Cached API should be the real API")
+
+    print = originalPrint
+end)
+
+-- Test: RefreshNexusGuardAPI forces relookup
+test("RefreshNexusGuardAPI forces relookup", function()
+    -- Set a dummy API first
+    Utils.nexusGuardAPI = { Utils = { Log = function() end }, Config = {} }
+    Utils.nexusGuardAPIDummy = true
+    _G.NexusGuard = nil
+
+    -- Provide real API and refresh
+    local refreshedLogs = {}
+    _G.NexusGuard = { Utils = { Log = function(msg) table.insert(refreshedLogs, msg) end }, Config = {} }
+    Utils.RefreshNexusGuardAPI()
+    Utils.Log("refreshed")
+
+    assert(#refreshedLogs > 0, "Refresh should use real API")
+end)
+
+print(string.format("\nTest Summary: %d passed, %d failed, %d total", tests.passed, tests.failed, tests.total))
+return tests


### PR DESCRIPTION
## Summary
- Retry NexusGuard API lookup when cached value is fallback
- Add `RefreshNexusGuardAPI` helper for manual relookup
- Test that logging swaps to real API after refresh

## Testing
- `lua tests/module_loader_test.lua` *(fails: Non-existent module should return nil; Optional non-existent module should return nil without error; Different module instances should be returned after clearing cache)*
- `lua tests/natives_test.lua` *(fails: IsDuplicityVersion should exist in the Natives wrapper; GetEntityCoords should return the correct x coordinate; GetPlayerName should return nil for a failed call; GetPlayerName should handle errors and return nil)*
- `lua tests/utils_log_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68978986069083278504672adebc1e8e