### PR TITLE
feat: add table size utility

### DIFF
--- a/NexusGuard/docs/core_modules.md
+++ b/NexusGuard/docs/core_modules.md
@@ -101,12 +101,12 @@ local Utils = ModuleLoader.Load('shared/utils')
 Utils.Log("Player connected: %s", Utils.logLevels.INFO, playerName)
 ```
 
-#### `Utils.TableSize(table)`
+#### `Utils.TableSize(tbl)`
 
-Returns the number of elements in a table.
+Counts the number of key/value pairs in a table using `pairs`.
 
 **Parameters:**
-- `table` (table): The table to count elements in
+- `tbl` (table): The table to count elements in
 
 **Returns:**
 - (number): The number of elements in the table

--- a/NexusGuard/shared/utils.lua
+++ b/NexusGuard/shared/utils.lua
@@ -244,6 +244,20 @@ function Utils.Hash(data, algorithm)
     return tostring(hash)
 end
 
+-- Count the number of key/value pairs in a table
+function Utils.TableSize(tbl)
+    if type(tbl) ~= "table" then
+        return 0
+    end
+
+    local count = 0
+    for _ in pairs(tbl) do
+        count = count + 1
+    end
+
+    return count
+end
+
 -- Get connected players with caching
 function Utils.GetConnectedPlayers()
     -- Check cache first


### PR DESCRIPTION
## Summary
- add `Utils.TableSize` helper to count table entries
- document `Utils.TableSize` in core module docs

## Testing
- `lua tests/module_loader_test.lua` *(fails: Non-existent module should return nil)*
- `lua tests/natives_test.lua` *(fails: IsDuplicityVersion should exist in the Natives wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_689789871fc083278f042a716ff7ff7f