### PR TITLE
refactor: centralize server API table

### DIFF
--- a/NexusGuard/client_main.lua
+++ b/NexusGuard/client_main.lua
@@ -34,7 +34,6 @@ if not DetectorRegistry then
     -- Consider halting initialization if the registry is crucial.
 end
 
--- REMOVED _G.NexusGuard ASSIGNMENT
 
 -- Environment Check & Debug Compatibility
 -- Attempts to detect if running outside a standard FiveM client environment (e.g., for testing).
@@ -161,7 +160,7 @@ local isDebugEnvironment = type(Citizen) ~= "table" or type(Citizen.CreateThread
             -- 3. Add `Config.Detectors.mydetector = true` (or false) to config.lua.
         }
     }
-    -- _G.NexusGuard = NexusGuardInstance -- REMOVED: Avoid global assignment. Instance passed via Initialize.
+    -- Instance is intentionally not assigned to a global; detectors receive it during Initialize.
 
     --[[
         Safe Detection Wrapper (Called by detector threads)


### PR DESCRIPTION
## Summary
- expose admin and ban helpers via returned `NexusGuardServer` table
- load server API with `require` in server_main and call new helpers
- clarify client initialization to avoid global `NexusGuard`

## Testing
- `lua tests/module_loader_test.lua` *(fails: Non-existent module should return nil, Optional non-existent module should return nil without error, Different module instances should be returned after clearing cache)*
- `lua tests/natives_test.lua` *(fails: IsDuplicityVersion should exist in the Natives wrapper, GetEntityCoords should return the correct x coordinate, GetPlayerName should return nil for a failed call, GetPlayerName should handle errors and return nil)*

------
https://chatgpt.com/codex/tasks/task_e_689789a87cdc8327bf88c77670ee7772