### PR TITLE
Handle screenshot failure event with server validation

### DIFF
--- a/NexusGuard/docs/event_validation_patterns.md
+++ b/NexusGuard/docs/event_validation_patterns.md
@@ -1,0 +1,40 @@
+# Event Validation Patterns
+
+This document summarizes client-to-server event patterns in NexusGuard and the corresponding validation performed on the server. Each handler verifies the authenticity of the client's security token and checks relevant state to prevent tampering.
+
+## SECURITY_REQUEST_TOKEN
+- Ensures the client hash is a valid string before generating and returning a security token.
+
+## DETECTION_REPORT
+- Validates the security token.
+- Retrieves the player's session before passing data to the detections module.
+
+## SYSTEM_RESOURCE_CHECK
+- Validates the security token.
+- Requires the resource list to be a table and compares it against whitelist/blacklist configuration.
+
+## SYSTEM_ERROR
+- Validates the security token.
+- Records the error in the player's session metrics.
+
+## ADMIN_SCREENSHOT_TAKEN
+- Validates the security token.
+- Requires a non-empty screenshot URL string before logging and forwarding the event.
+
+## ADMIN_SCREENSHOT_FAILED
+- Validates the security token.
+- Requires a textual error reason and records the failure for review.
+
+## NEXUSGUARD_POSITION_UPDATE
+- Validates the security token.
+- Confirms position data is a `vector3` and updates session metrics before delegating to position validation logic.
+
+## NEXUSGUARD_HEALTH_UPDATE
+- Validates the security token.
+- Uses the session data to verify health and armor values via the detections module.
+
+## NEXUSGUARD_WEAPON_CHECK
+- Validates the security token.
+- Compares reported clip counts against configured weapon limits and raises detections on mismatch.
+
+All handlers rely on `NexusGuardServer.Security.ValidateToken` for token authentication and make use of session data retrieved via `NexusGuardServer.GetSession` when necessary.

--- a/NexusGuard/server/server_main.lua
+++ b/NexusGuard/server/server_main.lua
@@ -479,17 +479,54 @@ function RegisterNexusGuardServerEvents()
         end
     end)
 
-     -- Screenshot Taken Handler (Client -> Server)
-     -- Client confirms a screenshot was taken and provides the URL.
-     EventRegistry:AddEventHandler('ADMIN_SCREENSHOT_TAKEN', function(screenshotUrl, tokenData)
+    -- Screenshot Failure Handler (Client -> Server)
+    -- Client reports that a screenshot capture or upload failed.
+    EventRegistry:AddEventHandler('ADMIN_SCREENSHOT_FAILED', function(errorMessage, tokenData)
         local source = source -- Capture player source ID.
         if not source or source <= 0 then return end
         local playerName = GetPlayerName(source) or ("Unknown (" .. source .. ")")
 
         -- CRITICAL: Validate the security token.
         if not NexusGuardServer.Security or not NexusGuardServer.Security.ValidateToken or not NexusGuardServer.Security.ValidateToken(source, tokenData) then
-             Log(("^1[NexusGuard] Invalid security token received with screenshot confirmation from %s (ID: %d). Banning player.^7"):format(playerName, source), 1)
-             if NexusGuardServer.Bans.Execute then NexusGuardServer.Bans.Execute(source, 'Invalid security token with screenshot confirmation') else DropPlayer(source, "Anti-Cheat validation failed (Screenshot Confirmation Token).") end
+            Log(("^1[NexusGuard] Invalid security token received with screenshot failure from %s (ID: %d). Banning player.^7"):format(playerName, source), 1)
+            if NexusGuardServer.Bans.Execute then NexusGuardServer.Bans.Execute(source, 'Invalid security token with screenshot failure') else DropPlayer(source, "Anti-Cheat validation failed (Screenshot Failure Token).") end
+            return
+        end
+
+        -- Validate error message format.
+        if type(errorMessage) ~= "string" then
+            Log(("^1[NexusGuard] Invalid screenshot failure data received from %s (ID: %d). Ignoring.^7"):format(playerName, source), 1)
+            return
+        end
+
+        Log(("^3[NexusGuard]^7 Screenshot capture failed for %s (ID: %d): %s^7"):format(playerName, source, errorMessage), 3)
+        if NexusGuardServer.Discord and NexusGuardServer.Discord.Send then
+            NexusGuardServer.Discord.Send("general", 'Screenshot Failed', ("Player: %s (ID: %d)\nError: %s"):format(playerName, source, errorMessage), NexusGuardServer.Config.Discord.webhooks and NexusGuardServer.Config.Discord.webhooks.general)
+        end
+        local session = NexusGuardServer.GetSession(source)
+        if session and session.metrics then
+            if not session.metrics.screenshotFailures then session.metrics.screenshotFailures = {} end
+            table.insert(session.metrics.screenshotFailures, { error = errorMessage, time = os.time() })
+        end
+    end)
+
+    -- Screenshot Taken Handler (Client -> Server)
+    -- Client confirms a screenshot was taken and provides the URL.
+    EventRegistry:AddEventHandler('ADMIN_SCREENSHOT_TAKEN', function(screenshotUrl, tokenData)
+        local source = source -- Capture player source ID.
+        if not source or source <= 0 then return end
+        local playerName = GetPlayerName(source) or ("Unknown (" .. source .. ")")
+
+        -- CRITICAL: Validate the security token.
+        if not NexusGuardServer.Security or not NexusGuardServer.Security.ValidateToken or not NexusGuardServer.Security.ValidateToken(source, tokenData) then
+            Log(("^1[NexusGuard] Invalid security token received with screenshot confirmation from %s (ID: %d). Banning player.^7"):format(playerName, source), 1)
+            if NexusGuardServer.Bans.Execute then NexusGuardServer.Bans.Execute(source, 'Invalid security token with screenshot confirmation') else DropPlayer(source, "Anti-Cheat validation failed (Screenshot Confirmation Token).") end
+            return
+        end
+
+        -- Validate screenshot URL format.
+        if type(screenshotUrl) ~= "string" or screenshotUrl == "" then
+            Log(("^1[NexusGuard] Invalid screenshot URL received from %s (ID: %d). Ignoring.^7"):format(playerName, source), 1)
             return
         end
 

--- a/NexusGuard/shared/event_registry.lua
+++ b/NexusGuard/shared/event_registry.lua
@@ -52,6 +52,7 @@ EventRegistry.events = {
     ADMIN_NOTIFICATION = "admin:notification",       -- Server -> Client: Server sends a notification message specifically to an admin client.
     ADMIN_REQUEST_SCREENSHOT = "admin:requestScreenshot", -- Server -> Client: Server requests the client to take and upload a screenshot.
     ADMIN_SCREENSHOT_TAKEN = "admin:screenshotTaken",   -- Client -> Server: Client confirms screenshot was taken and provides the URL.
+    ADMIN_SCREENSHOT_FAILED = "admin:screenshotFailed", -- Client -> Server: Client reports screenshot capture/upload failure.
 
     -- System Status & Checks (Client -> Server)
     SYSTEM_ERROR = "system:error",             -- Client -> Server: Client reports an internal error (e.g., in a detector).


### PR DESCRIPTION
## Summary
- track `ADMIN_SCREENSHOT_FAILED` events with token and state validation
- harden `ADMIN_SCREENSHOT_TAKEN` to require a valid screenshot URL
- document standard client→server event validation patterns

## Testing
- `LUA_PATH='NexusGuard/?.lua;NexusGuard/?/init.lua;;' lua NexusGuard/tests/module_loader_test.lua` *(fails: Non-existent module should return nil)*
- `LUA_PATH='NexusGuard/?.lua;NexusGuard/?/init.lua;;' lua NexusGuard/tests/natives_test.lua` *(fails: IsDuplicityVersion should exist in the Natives wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_689789aec4408327bf1f5b4b96bfa753