### PR TITLE
feat: normalize detection data and add storage helper

### DIFF
--- a/NexusGuard/globals.lua
+++ b/NexusGuard/globals.lua
@@ -77,6 +77,24 @@ function NexusGuardServer.ProcessDetection(playerId, detectionType, detectionDat
     return Core.ProcessDetection(playerId, detectionType, detectionData)
 end
 
+-- Store detection data in a normalized format through the Database module.
+NexusGuardServer.Detections = NexusGuardServer.Detections or {}
+function NexusGuardServer.Detections.Store(playerId, detectionType, detectionData)
+    if type(detectionData) ~= "table" then
+        detectionData = { value = detectionData, details = {}, clientValidated = false, serverValidated = false }
+    else
+        detectionData.value = detectionData.value
+        detectionData.details = detectionData.details or {}
+        detectionData.clientValidated = detectionData.clientValidated or false
+        detectionData.serverValidated = detectionData.serverValidated or false
+    end
+
+    if NexusGuardServer.Database and NexusGuardServer.Database.StoreDetection then
+        return NexusGuardServer.Database.StoreDetection(playerId, detectionType, detectionData)
+    end
+    return false
+end
+
 -- Get the current status of the NexusGuard system.
 function NexusGuardServer.GetStatus()
     return Core.GetStatus()

--- a/NexusGuard/server/modules/detections.lua
+++ b/NexusGuard/server/modules/detections.lua
@@ -189,8 +189,8 @@ local function ApplyPenalty(playerId, session, detectionType, validatedData, sev
             timestamp = os.time()
         })
         -- Also store in database if configured
-        if NexusGuardServer.Database and NexusGuardServer.Database.StoreDetection then
-            NexusGuardServer.Database.StoreDetection(playerId, detectionType, details) -- Pass original details table
+        if NexusGuardServer.Detections and NexusGuardServer.Detections.Store then
+            NexusGuardServer.Detections.Store(playerId, detectionType, validatedData)
         end
     else
          Log(("^1Detections Penalty Warning: Cannot apply trust score penalty or store detection for %s (ID: %d) - session or metrics missing.^7"):format(playerName, playerId), 1)

--- a/NexusGuard/server/server_main.lua
+++ b/NexusGuard/server/server_main.lua
@@ -227,7 +227,7 @@ function OnPlayerConnecting(playerName, setKickReason, deferrals)
     Log(("^2[NexusGuard]^7 Player connection approved: %s (ID: %d, License: %s)^7"):format(playerName, source, license or "N/A"), 2)
     -- Finalize the deferral, allowing the player to join.
     deferrals.done()
-end)
+end
 
 --[[
     Player Disconnected Handler Function (OnPlayerDropped)
@@ -340,12 +340,24 @@ function RegisterNexusGuardServerEvents()
             return
         end
 
+        -- Normalize detection data before processing
+        if type(detectionData) ~= "table" then
+            detectionData = { value = detectionData, details = {}, clientValidated = true, serverValidated = false }
+        else
+            detectionData = {
+                value = detectionData.value,
+                details = detectionData.details or detectionData,
+                clientValidated = true,
+                serverValidated = detectionData.serverValidated or false
+            }
+        end
+
         -- Process the detection using the Detections module via API.
         if NexusGuardServer.Detections and NexusGuardServer.Detections.Process then
-             -- Pass the player ID, detection details, and the full session object to the processing function.
-             NexusGuardServer.Detections.Process(source, detectionType, detectionData, session)
+            -- Pass the player ID, detection details, and the full session object to the processing function.
+            NexusGuardServer.Detections.Process(source, detectionType, detectionData, session)
         else
-             Log(("^1[NexusGuard] CRITICAL: Detections.Process function not found in API! Cannot process detection '%s' from %s (ID: %d)^7"):format(tostring(detectionType), playerName, source), 1)
+            Log(("^1[NexusGuard] CRITICAL: Detections.Process function not found in API! Cannot process detection '%s' from %s (ID: %d)^7"):format(tostring(detectionType), playerName, source), 1)
         end
     end)
 
@@ -432,7 +444,12 @@ function RegisterNexusGuardServerEvents()
                 -- Process this as a detection event.
                 local session = NexusGuardServer.GetSession(source) -- Get session via API
                 if NexusGuardServer.Detections and NexusGuardServer.Detections.Process then
-                    NexusGuardServer.Detections.Process(source, "ResourceMismatch", { mismatched = MismatchedResources, mode = checkMode }, session)
+                    NexusGuardServer.Detections.Process(source, "ResourceMismatch", {
+                        value = #MismatchedResources,
+                        details = { mismatched = MismatchedResources, mode = checkMode },
+                        clientValidated = false,
+                        serverValidated = true
+                    }, session)
                 end
                 -- Ban or kick based on config.
                 if rvConfig.banOnMismatch then
@@ -644,10 +661,15 @@ function RegisterNexusGuardServerEvents()
                 -- Process as a detection event.
                 if NexusGuardServer.Detections.Process then
                     NexusGuardServer.Detections.Process(source, "ServerWeaponClipCheck", {
-                        weaponHash = weaponHash,
-                        reportedClip = clipCount,
-                        baseClip = baseClipSize,
-                        maxAllowed = maxAllowedClip
+                        value = clipCount,
+                        details = {
+                            weaponHash = weaponHash,
+                            reportedClip = clipCount,
+                            baseClip = baseClipSize,
+                            maxAllowed = maxAllowedClip
+                        },
+                        clientValidated = false,
+                        serverValidated = true
                     }, session)
                 end
             end

--- a/NexusGuard/server/sv_event_handlers.lua
+++ b/NexusGuard/server/sv_event_handlers.lua
@@ -86,7 +86,13 @@ function EventHandlers.HandleExplosion(sender, ev, session)
 
         -- Process this as a detection event via the Detections API.
         if NexusGuardServer.Detections and NexusGuardServer.Detections.Process then
-            NexusGuardServer.Detections.Process(source, "BlacklistedExplosion", { type = explosionType, position = position }, session)
+            -- Normalize detection data structure
+            NexusGuardServer.Detections.Process(source, "BlacklistedExplosion", {
+                value = explosionType,
+                details = { type = explosionType, position = position },
+                clientValidated = false,
+                serverValidated = true
+            }, session)
         else Log("^1[NexusGuard EH] Detections.Process API function not found! Cannot process BlacklistedExplosion detection.^7", 1) end
 
         -- Apply immediate ban or kick if configured, using the Bans API.
@@ -146,12 +152,17 @@ function EventHandlers.HandleExplosion(sender, ev, session)
         -- Process this as an "ExplosionSpam" detection event via the Detections API.
         if NexusGuardServer.Detections and NexusGuardServer.Detections.Process then
             NexusGuardServer.Detections.Process(source, "ExplosionSpam", {
-                count = recentCount,
-                period = spamTimeWindow,
-                areaCount = spamInAreaCount,
-                areaDistance = spamDistanceThreshold,
-                lastType = explosionType,
-                lastPosition = position
+                value = recentCount,
+                details = {
+                    count = recentCount,
+                    period = spamTimeWindow,
+                    areaCount = spamInAreaCount,
+                    areaDistance = spamDistanceThreshold,
+                    lastType = explosionType,
+                    lastPosition = position
+                },
+                clientValidated = false,
+                serverValidated = true
             }, session) -- Pass the full session object.
         else Log("^1[NexusGuard EH] Detections.Process API function not found! Cannot process ExplosionSpam detection.^7", 1) end
     end


### PR DESCRIPTION
## Summary
- add NexusGuardServer.Detections.Store for normalized detection persistence
- standardize detectionData tables before calling Detections.Process across server handlers
- route detection logging through new Store helper

## Testing
- `lua tests/module_loader_test.lua` *(fails: Non-existent module should return nil, Optional non-existent module should return nil without error, Different module instances should be returned after clearing cache)*
- `lua tests/natives_test.lua` *(fails: IsDuplicityVersion should exist, GetEntityCoords should return correct value, GetPlayerName returns nil, GetPlayerName should handle errors)*

------
https://chatgpt.com/codex/tasks/task_e_689789b46464832796f01137b3427197