### PR TITLE
feat: prototype event proxy channel

### DIFF
--- a/NexusGuard/client/event_proxy.lua
+++ b/NexusGuard/client/event_proxy.lua
@@ -1,0 +1,34 @@
+--[[
+    NexusGuard Event Proxy (client/event_proxy.lua)
+
+    Prototype module inspired by GoblinAC's event proxy system. Encodes
+    event data and sends it through a controlled channel that validates a
+    per-client key on the server before dispatching the real event.
+]]
+
+local EventRegistry = require('shared/event_registry')
+
+local EventProxy = {
+    key = nil
+}
+
+-- Receive the proxy key from the server
+RegisterNetEvent('ng_proxy:setKey', function(k)
+    EventProxy.key = k
+end)
+
+-- Trigger a server event through the proxy channel
+function EventProxy:TriggerServer(eventKey, ...)
+    if not self.key then
+        print(('^1[NexusGuard] Missing proxy key. Event %s not sent.^7'):format(tostring(eventKey)))
+        return
+    end
+
+    local eventName = EventRegistry:GetEventName(eventKey)
+    if not eventName then return end
+
+    local payload = json.encode({ event = eventName, args = { ... } })
+    TriggerServerEvent('ng_proxy:trigger', payload, self.key)
+end
+
+return EventProxy

--- a/NexusGuard/client_main.lua
+++ b/NexusGuard/client_main.lua
@@ -34,7 +34,7 @@ if not DetectorRegistry then
     -- Consider halting initialization if the registry is crucial.
 end
 
--- REMOVED _G.NexusGuard ASSIGNMENT
+local EventProxy = require('client/event_proxy')
 
 -- Environment Check & Debug Compatibility
 -- Attempts to detect if running outside a standard FiveM client environment (e.g., for testing).
@@ -191,11 +191,11 @@ local isDebugEnvironment = type(Citizen) ~= "table" or type(Citizen.CreateThread
             if errorInfo.count > errorThreshold and (GetGameTimer() - errorInfo.firstSeen < errorTimeWindow) then
                 print(("^1[NexusGuard] Detector '%s' is persistently failing. Reporting error to server.^7"):format(detectionName))
                 if self.securityToken then -- Ensure we have a token to send
-                    if EventRegistry then
+                    if EventProxy then
                         -- Send the error details along with the security token for validation server-side.
-                        EventRegistry:TriggerServerEvent('SYSTEM_ERROR', detectionName, tostring(err), self.securityToken)
+                        EventProxy:TriggerServer('SYSTEM_ERROR', detectionName, tostring(err), self.securityToken)
                     else
-                        print("^1[NexusGuard] CRITICAL: EventRegistry module not loaded. Cannot report client error to server.^7")
+                        print("^1[NexusGuard] CRITICAL: EventProxy module not loaded. Cannot report client error to server.^7")
                     end
                 else
                     print("^3[NexusGuard] Warning: Cannot report persistent detector error to server - security token not yet received.^7")
@@ -248,13 +248,13 @@ local isDebugEnvironment = type(Citizen) ~= "table" or type(Citizen.CreateThread
 
             -- Request the security token from the server. This is crucial for validating subsequent client->server events.
             print("^2[NexusGuard]^7 Requesting security token from server...")
-            if EventRegistry then
+            if EventProxy then
                 -- Note: The clientHash sent here is currently basic and not cryptographically secure for client identification.
                 -- A more robust system might involve server-generated challenges.
                 local clientHash = GetCurrentResourceName() .. "-" .. math.random(100000, 999999)
-                EventRegistry:TriggerServerEvent('SECURITY_REQUEST_TOKEN', clientHash)
+                EventProxy:TriggerServer('SECURITY_REQUEST_TOKEN', clientHash)
             else
-                print("^1[NexusGuard] CRITICAL: EventRegistry module not loaded. Cannot request security token.^7")
+                print("^1[NexusGuard] CRITICAL: EventProxy module not loaded. Cannot request security token.^7")
                 -- Initialization might need to halt here if the token is absolutely required early on.
             end
 
@@ -614,12 +614,12 @@ local isDebugEnvironment = type(Citizen) ~= "table" or type(Citizen.CreateThread
         else
             -- For subsequent detections after the initial warning, report directly to the server.
             print(("^1[NexusGuard] Reporting Detection to Server - Type: %s, Details: %s^7"):format(tostring(detectionType), tostring(details)))
-            if EventRegistry then
+            if EventProxy then
                 -- Send the detection type, details, and the security token to the server for verification and action.
-                EventRegistry:TriggerServerEvent('DETECTION_REPORT', detectionType, details, self.securityToken)
+                EventProxy:TriggerServer('DETECTION_REPORT', detectionType, details, self.securityToken)
             else
-                -- EventRegistry is essential for server communication.
-                print("^1[NexusGuard] CRITICAL: EventRegistry module not loaded. Cannot report detection to server.^7")
+                -- EventProxy is essential for server communication.
+                print("^1[NexusGuard] CRITICAL: EventProxy module not loaded. Cannot report detection to server.^7")
             end
         end
     end

--- a/NexusGuard/fxmanifest.lua
+++ b/NexusGuard/fxmanifest.lua
@@ -13,6 +13,7 @@ shared_scripts {
 }
 
 client_scripts {
+    'client/event_proxy.lua',
     'client/client_main.lua',
     'client/detectors/*.lua'
 }
@@ -26,6 +27,7 @@ server_scripts {
     'server/sv_core.lua',            -- Load core module (handles module loading)
     'server/sv_permissions.lua',
     'server/sv_security.lua',
+    'server/sv_event_proxy.lua',
     'server/sv_session.lua',        -- Load session management module
     'server/sv_bans.lua',
     'server/sv_database.lua',       -- Load database module

--- a/NexusGuard/server/sv_event_proxy.lua
+++ b/NexusGuard/server/sv_event_proxy.lua
@@ -1,0 +1,40 @@
+--[[
+    NexusGuard Event Proxy (server/sv_event_proxy.lua)
+
+    Simplified proxy channel that validates a per-client key before
+    dispatching events. Inspired by GoblinAC's approach to securing
+    TriggerServerEvent calls.
+]]
+
+local EventProxy = {}
+local activeKeys = {}
+
+local function generateKey()
+    return string.format('%x%x', math.random(0, 0xffffff), math.random(0, 0xffffff))
+end
+
+AddEventHandler('playerJoining', function()
+    local src = source
+    local key = generateKey()
+    activeKeys[src] = key
+    TriggerClientEvent('ng_proxy:setKey', src, key)
+end)
+
+AddEventHandler('playerDropped', function()
+    activeKeys[source] = nil
+end)
+
+RegisterNetEvent('ng_proxy:trigger', function(payload, key)
+    local src = source
+    if not payload or not key or activeKeys[src] ~= key then
+        print(('^1[NexusGuard] Invalid proxy trigger from %s^7'):format(src))
+        return
+    end
+
+    local data = json.decode(payload or '{}')
+    if not data or not data.event then return end
+
+    TriggerEvent(data.event, src, table.unpack(data.args or {}))
+end)
+
+return EventProxy


### PR DESCRIPTION
## Summary
- add client/server proxy modules that encode event data and validate per-player keys
- integrate proxy into manifest and replace direct TriggerServerEvent calls for token requests, system errors, and detection reports

## Testing
- `luac -p client/event_proxy.lua server/sv_event_proxy.lua client_main.lua fxmanifest.lua`
- `lua tests/module_loader_test.lua` *(fails: Non-existent module and optional module tests)*
- `lua tests/natives_test.lua` *(fails: native wrapper expectations)*

------
https://chatgpt.com/codex/tasks/task_e_689789b7e4308327bb51e8077fce655f