### PR TITLE
Validate Discord webhook domains and whitelist specific URLs

### DIFF
--- a/NexusGuard/config.lua
+++ b/NexusGuard/config.lua
@@ -339,6 +339,11 @@ Config.Discord = {
         } -- Closing brace for Config.Discord.bot.notifications
         }, -- Closing brace for Config.Discord.bot
 
+        webhookWhitelist = {
+            -- Add full Discord webhook URLs that can be used with the specificWebhook parameter
+            -- "https://discord.com/api/webhooks/1234567890/abcdef",
+        },
+
         webhooks = {
             general = "", -- General anti-cheat logs (Can be the same as Config.DiscordWebhook)
             bans = "", -- Ban notifications (Can be the same as Config.DiscordWebhook)


### PR DESCRIPTION
## Summary
- check Discord webhook URLs against allowed domains before sending
- ignore `specificWebhook` unless it matches a whitelist from config
- add config option for whitelisted Discord webhook URLs

## Testing
- `lua tests/module_loader_test.lua` *(fail: module loader test failures)*
- `lua tests/natives_test.lua` *(fail: natives wrapper test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68978e892acc8327874047aed7a48937