### PR TITLE
Clarify anti-replay token behavior

### DIFF
--- a/NexusGuard/README.md
+++ b/NexusGuard/README.md
@@ -10,6 +10,7 @@ NexusGuard is a modular, event-driven anti-cheat framework designed for FiveM se
 *   **Event-Driven Architecture**: Uses standardized events for communication via `shared/event_registry.lua`.
 *   **Client & Server Logic**: Basic separation of client-side checks and server-side validation/actions.
 *   **Configuration**: Extensive configuration options via `config.lua`.
+*   **Secure Token System**: Includes HMAC-SHA256 tokens with anti-replay protection.
 *   **Basic Detections Included**: Examples for God Mode, Speed Hack, NoClip, Teleport, Weapon Mods, Resource Monitoring, Menu Keybinds.
 *   **Helper Utilities**: Basic logging, database-driven ban system (requires setup), admin notifications.
 *   **Discord Integration**: Basic webhook logging and Rich Presence support.
@@ -56,7 +57,7 @@ NexusGuard is a modular, event-driven anti-cheat framework designed for FiveM se
 
 *   **`config.lua`**: Contains all user-configurable settings. Read the comments carefully.
 *   **`Config.SecuritySecret`**: **MUST BE CHANGED** to a strong, unique secret. This is used by the default secure token system.
-*   **Security Implementation**: A default secure token system using HMAC-SHA256 (via `ox_lib`) is now included. Ensure `ox_lib` is installed and `Config.SecuritySecret` is set correctly.
+*   **Security Implementation**: A default secure token system using HMAC-SHA256 (via `ox_lib`) with built-in anti-replay protection is now included. Ensure `ox_lib` is installed and `Config.SecuritySecret` is set correctly.
 *   **Permissions**: Configure `Config.PermissionsFramework` and `Config.AdminGroups` in `config.lua`. You only need to edit `globals.lua` if using the `"custom"` framework setting.
 *   **Resource Verification**: The logic is implemented, but if enabled, the `whitelist` or `blacklist` in `config.lua` **MUST BE CONFIGURED ACCURATELY**. Whitelist mode is dangerous if not all required resources are listed.
 *   **Thresholds**: Tune detection thresholds (`Config.Thresholds`) carefully through testing.

--- a/NexusGuard/config.lua
+++ b/NexusGuard/config.lua
@@ -38,7 +38,7 @@ Config.SecuritySecret = "!!CHANGE_THIS_TO_A_SECURE_RANDOM_STRING!!" -- CRITICAL:
 Config.Security = {
     TokenValidityWindow = 60, -- Seconds a token is considered valid after generation (Default: 60)
     TokenCacheCleanupIntervalMs = 60000, -- Milliseconds between cleaning up expired tokens from the anti-replay cache (Default: 60000 = 1 minute)
-    -- TODO: Implement replay prevention by tracking used token signatures within the validity window.
+    -- Anti-replay protection: token signatures are cached to prevent reuse within the validity window.
 }
 
 -- [[ DEPRECATED / PLACEHOLDER SECTIONS REMOVED ]]

--- a/NexusGuard/docs/configuration_guide.md
+++ b/NexusGuard/docs/configuration_guide.md
@@ -26,11 +26,17 @@ Config.KickMessage = "You have been kicked for suspicious activity."
 
 -- Security Settings
 Config.SecuritySecret = "CHANGE_THIS_TO_A_LONG_RANDOM_STRING" -- CRITICAL: Change this!
+Config.Security = {
+    TokenValidityWindow = 60, -- Seconds a token remains valid
+    TokenCacheCleanupIntervalMs = 60000 -- Anti-replay cache cleanup interval (ms)
+}
 
 -- Permission Settings
 Config.PermissionsFramework = "ace" -- Options: "ace", "esx", "qbcore", "custom"
 Config.AdminGroups = {"admin", "superadmin"} -- Admin group names in your framework
 ```
+
+Tokens include built-in anti-replay protection. `TokenValidityWindow` sets how long a token is valid, and `TokenCacheCleanupIntervalMs` controls cleanup of cached signatures used to prevent replays.
 
 ### Enabling/Disabling Detectors
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ NexusGuard is a modular, event-driven anti-cheat framework designed for FiveM se
 *   **Event-Driven Architecture**: Uses standardized events for communication via `shared/event_registry.lua`.
 *   **Client & Server Logic**: Basic separation of client-side checks and server-side validation/actions.
 *   **Configuration**: Extensive configuration options via `config.lua`.
+*   **Secure Token System**: Includes HMAC-SHA256 tokens with anti-replay protection.
 *   **Basic Detections Included**: Examples for God Mode, Speed Hack, NoClip, Teleport, Weapon Mods, Resource Monitoring, Menu Keybinds.
 *   **Helper Utilities**: Basic logging, database-driven ban system (requires setup), admin notifications.
 *   **Discord Integration**: Basic webhook logging and Rich Presence support.
@@ -56,7 +57,7 @@ NexusGuard is a modular, event-driven anti-cheat framework designed for FiveM se
 
 *   **`config.lua`**: Contains all user-configurable settings. Read the comments carefully.
 *   **`Config.SecuritySecret`**: **MUST BE CHANGED** to a strong, unique secret. This is used by the default secure token system.
-*   **Security Implementation**: A default secure token system using HMAC-SHA256 (via `ox_lib`) is now included. Ensure `ox_lib` is installed and `Config.SecuritySecret` is set correctly.
+*   **Security Implementation**: A default secure token system using HMAC-SHA256 (via `ox_lib`) with built-in anti-replay protection is now included. Ensure `ox_lib` is installed and `Config.SecuritySecret` is set correctly.
 *   **Permissions**: Configure `Config.PermissionsFramework` and `Config.AdminGroups` in `config.lua`. You only need to edit `globals.lua` if using the `"custom"` framework setting.
 *   **Resource Verification**: The logic is implemented, but if enabled, the `whitelist` or `blacklist` in `config.lua` **MUST BE CONFIGURED ACCURATELY**. Whitelist mode is dangerous if not all required resources are listed.
 *   **Thresholds**: Tune detection thresholds (`Config.Thresholds`) carefully through testing.


### PR DESCRIPTION
## Summary
- remove outdated replay-prevention TODO from security config
- document token anti-replay settings in configuration guide and READMEs

## Testing
- `lua tests/module_loader_test.lua` (fails: Non-existent module should return nil)
- `lua tests/natives_test.lua` (fails: IsDuplicityVersion should exist in the Natives wrapper)


------
https://chatgpt.com/codex/tasks/task_e_68978e8a04088327a27f49882589720a