### PR TITLE
refactor: require secure randomness for nonces

### DIFF
--- a/NexusGuard/server/server_main.lua
+++ b/NexusGuard/server/server_main.lua
@@ -294,7 +294,7 @@ function RegisterNexusGuardServerEvents()
             ClientsLoaded[source] = true -- Mark client as having initiated the handshake.
             -- Generate a security token using the Security module via API.
             local tokenData = NexusGuardServer.Security and NexusGuardServer.Security.GenerateToken and NexusGuardServer.Security.GenerateToken(source)
-            if tokenData then
+            if tokenData and tokenData.nonce then
                 -- Send the generated token data back to the requesting client.
                 EventRegistry:TriggerClientEvent('SECURITY_RECEIVE_TOKEN', source, tokenData)
                 Log(("^2[NexusGuard]^7 Secure token sent to %s (ID: %d) via event '%s'^7"):format(playerName, source, EventRegistry:GetEventName('SECURITY_RECEIVE_TOKEN')), 2)

--- a/NexusGuard/server/sv_security.lua
+++ b/NexusGuard/server/sv_security.lua
@@ -131,12 +131,12 @@ end
 
 --[[
     Generates a cryptographically secure random nonce.
-    Used to prevent replay attacks in security tokens.
+    Returns nil if a secure random generator is unavailable, disabling token issuance.
 
-    @return (string): A random nonce string, or nil on failure.
+    @return (string | nil): A random nonce string, or nil on failure.
 ]]
 function Security.GenerateNonce()
-    -- Try to use ox_lib's secure random function if available
+    -- Use ox_lib's secure random function if available
     if Dependencies.status.ox_lib.available and lib and lib.crypto and lib.crypto.randomBytes then
         local success, result = pcall(function()
             return lib.crypto.randomBytes(Security.nonceLength)
@@ -144,23 +144,15 @@ function Security.GenerateNonce()
 
         if success and result then
             return result
+        else
+            Log("^1SECURITY ERROR: Failed to generate secure random bytes for nonce.^7", 1)
+            return nil
         end
     end
 
-    -- Fallback to a less secure but still reasonable method
-    local chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    local length = Security.nonceLength * 2 -- Compensate for lower entropy
-    local nonce = ""
-
-    -- Seed the random number generator with current time and player count
-    math.randomseed(os.time() + os.clock() * 1000)
-
-    for i = 1, length do
-        local randIndex = math.random(1, #chars)
-        nonce = nonce .. string.sub(chars, randIndex, randIndex)
-    end
-
-    return nonce
+    -- Secure random generator not available
+    Log("^1SECURITY CRITICAL: Secure random generator unavailable. Cannot generate nonce.^7", 1)
+    return nil
 end
 
 --[[


### PR DESCRIPTION
## Summary
- use lib.crypto.randomBytes for nonce generation and drop insecure math.random fallback
- log critical error and return nil when secure randomness unavailable
- ensure token requests handle missing nonce

## Testing
- `luac -p NexusGuard/server/sv_security.lua`
- `luac -p NexusGuard/server/server_main.lua`
- `lua NexusGuard/tests/module_loader_test.lua` *(fails: module 'shared/module_loader' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899aab921748327831e3e0fde21a0f0