### PR TITLE
Add challenge token system and server-side replay protection

### DIFF
--- a/NexusGuard/client/detectors/teleport_detector.lua
+++ b/NexusGuard/client/detectors/teleport_detector.lua
@@ -134,12 +134,6 @@ function Detector.Check()
                 -- Log(("[%s Detector] Client detected potential teleport: %s"):format(DetectorName, reason), 2) -- Log locally if desired
 
                 -- NOTE: Reporting removed. Server-side position validation is more reliable.
-                -- if NexusGuard.ReportCheat then
-                --     NexusGuard:ReportCheat(DetectorName, {
-                --         reason = reason, distance = distance, timeDiff = timeDiff
-                --     })
-                -- end
-                -- return 1 -- Indicate suspicion for adaptive timing (optional)
             end
         end
     end

--- a/NexusGuard/shared/event_registry.lua
+++ b/NexusGuard/shared/event_registry.lua
@@ -43,6 +43,7 @@ EventRegistry.events = {
     -- Security Handshake (Client <-> Server)
     SECURITY_REQUEST_TOKEN = "security:requestToken", -- Client -> Server: Client requests a security token upon connection.
     SECURITY_RECEIVE_TOKEN = "security:receiveToken", -- Server -> Client: Server sends the generated security token data back to the client.
+    SECURITY_NEW_CHALLENGE = "security:newChallenge", -- Server -> Client: Server issues a new challenge token.
 
     -- Detection Reporting (Client -> Server)
     DETECTION_REPORT = "detection:report", -- Client -> Server: Client reports a detected violation with details and security token.


### PR DESCRIPTION
## Summary
- Track per-player token timestamps and invalidate replays within the validity window
- Require and rotate short-lived server challenge tokens across critical client-server events
- Adjust server speed checks for falling players and remove client teleport cheat reports

## Testing
- `lua tests/module_loader_test.lua` *(passes)*
- `lua tests/natives_test.lua` *(fails: `IsDuplicityVersion should exist in the Natives wrapper`)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5229070832783061800598ac18c