### PR TITLE
fix: clarify client entry path

### DIFF
--- a/NexusGuard/fxmanifest.lua
+++ b/NexusGuard/fxmanifest.lua
@@ -14,7 +14,7 @@ shared_scripts {
 
 client_scripts {
     'client/event_proxy.lua',
-    'client_main.lua',
+    'client_main.lua', -- Main client entry point
     'client/detectors/*.lua'
 }
 


### PR DESCRIPTION
## Summary
- clarify manifest client entry line so it points to the root-level client_main.lua

## Testing
- `lua NexusGuard/tests/natives_test.lua` *(fails: module 'shared/module_loader' not found)*
- `lua NexusGuard/tests/module_loader_test.lua` *(fails: module 'shared/module_loader' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b6f41270832796fd9d287df24b5f