### PR TITLE
chore: set unique security secret

### DIFF
--- a/NexusGuard/config.lua
+++ b/NexusGuard/config.lua
@@ -32,7 +32,7 @@ Config.AdminGroups = {"admin", "superadmin", "mod"} -- Groups considered admin b
 -- This secret is VITAL for securing communication between the client and server using HMAC-SHA256.
 -- **DO NOT SHARE THIS SECRET.** NexusGuard will log a CRITICAL error and stop the resource on startup if this is left as default or empty.
 -- Example of a strong secret (DO NOT USE THIS EXAMPLE): "p$z^8@!L#s&G*f@D9j!K3m$n&P@r*T(w"
-Config.SecuritySecret = "p$z^8@!L#s&G*f@D9j!K3m$n&P@r*T(w" -- Example of a strong random string
+Config.SecuritySecret = "9a8c2f7fa03d50c029a1cf90960824ada111ab002e6191b0f3ffafa98fbf4606" -- Generated security secret
 
 -- Security Token Settings
 Config.Security = {


### PR DESCRIPTION
## Summary
- replace example security secret with unique random string for token validation

## Testing
- `lua tests/module_loader_test.lua`
- `lua tests/natives_test.lua` *(fails: IsDuplicityVersion should exist in the Natives wrapper, GetEntityCoords should return the correct x coordinate, GetPlayerName should return nil for a failed call, GetPlayerName should handle errors and return nil)*

------
https://chatgpt.com/codex/tasks/task_e_6899b712638c8327a6c5b11e2b6df9d6